### PR TITLE
Test Remote Source

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
             name: "\(packageName)Tests",
             dependencies: ["GIFImage"],
             resources: [
-                .copy("test.gif")
+                .process("test.gif")
             ]
         )
     ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This package contains a SwiftUI View that is able to render a GIF, either from a
 
 ## Why not a GIF?
 
-![Hipster LLama](Tests/GIFImageTests/Resources/test.gif)
+![Hipster LLama](https://64.media.tumblr.com/eb81c4d7288732e2b6a9e63c166c623a/tumblr_mi3vj5Api71ryhf5lo1_400.gif)
 
 ## Use
 

--- a/Tests/GIFImageTests/ImageLoaderTests.swift
+++ b/Tests/GIFImageTests/ImageLoaderTests.swift
@@ -84,5 +84,18 @@ class ImageLoaderTests: XCTestCase {
         XCTAssertEqual(frameCount, testGIFFrameCount)
         XCTAssertTrue(duration.equal(testGIFDuration, precise: 2), "\(duration) is not equal to \(testGIFDuration)")
     }
+    
+    func testRemoteSourceLoading() async throws {
+        let urlSession = MockedURLProtocol.buildTestSession()
+        let fileManager = MockedFileManager()
+        MockedURLProtocol.register(.success(gifData), to: url)
+        
+        let imageLoader = ImageLoader(session: urlSession, cache: .shared, fileManager: fileManager)
+        let sequence = try await imageLoader.load(source: GIFSource.remote(url: url), loop: false)
+        
+        let (frameCount, duration) = try await sequence.reduce((0, 0.0)) { partial, frame in (partial.0 + 1, partial.1 + (frame.interval ?? 0.0)) }
+        XCTAssertEqual(frameCount, testGIFFrameCount)
+        XCTAssertTrue(duration.equal(testGIFDuration, precise: 2), "\(duration) is not equal to \(testGIFDuration)")
+    }
 
 }

--- a/Tests/GIFImageTests/InfrastructureTests.swift
+++ b/Tests/GIFImageTests/InfrastructureTests.swift
@@ -22,15 +22,12 @@ final class InfrastructureTests: XCTestCase {
     
     func testBasicMockStructure() async throws {
         let url = URL(string: "https://www.test.com")!
-        MockedURLProtocol.register(.failure(URLError(.fileDoesNotExist)), to: url)
+        MockedURLProtocol.register(.failure(URLError(.init(rawValue: 404))), to: url)
         let urlSession = MockedURLProtocol.buildTestSession()
         
-        do {
-            let _ = try await urlSession.data(for: URLRequest(url: url))
-            XCTFail("URL Session request should have thrown")
-        } catch {
-            XCTAssertEqual((error as? URLError)?.code, URLError.Code.fileDoesNotExist)
-        }
+        let (data, response) = try await urlSession.data(for: URLRequest(url: url))
+        XCTAssertEqual(data, Data())
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
     }
     
     func testMockedFileManager() async throws {

--- a/Tests/GIFImageTests/MockedURLProtocol.swift
+++ b/Tests/GIFImageTests/MockedURLProtocol.swift
@@ -54,7 +54,7 @@ final class MockedURLProtocol: URLProtocol {
     private func failRequest(url: URL, error: URLError) {
         let response = HTTPURLResponse(url: url, statusCode: error.code.rawValue, httpVersion: nil, headerFields: nil)!
         self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        self.client?.urlProtocol(self, didFailWithError: error)
+        self.client?.urlProtocolDidFinishLoading(self)
     }
     
     private func completeRequest(url: URL, data: Data) {


### PR DESCRIPTION
### Goal

Include tests for the remote source

### Implementation

1. Fix the `MockedURLProtocol` behaviour to ensure full HTTP response
2. Fix the infrastructure tests to match HTTP behaviour
3. Include the remote source in the tests