### PR TITLE
Include frame rate control

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ GIFImage.init(
     source: GIFSource,
     loop: Bool = true,
     placeholder: RawImage = RawImage(),
-    errorImage: RawImage? = nil
+    errorImage: RawImage? = nil,
+    frameRate: FrameRate = .dynamic
 )
 ```
 

--- a/Sources/GIFImage.swift
+++ b/Sources/GIFImage.swift
@@ -11,6 +11,7 @@ public struct GIFImage: View {
     public let loop: Bool
     public let placeholder: RawImage
     public let errorImage: RawImage?
+    public let frameRate: FrameRate
     
     @Environment(\.imageLoader) var imageLoader
     @State private var frame: RawImage? = nil
@@ -24,11 +25,13 @@ public struct GIFImage: View {
     ///   - loop: Flag to indicate if the GIF should be played only once or continue to loop
     ///   - placeholder: Image to be used before the source is loaded
     ///   - errorImage: If the stream fails, this image is used
-    public init(source: GIFSource, loop: Bool = true, placeholder: RawImage = RawImage(), errorImage: RawImage? = nil) {
+    ///   - frameRate: Option to control the frame rate of the animation or to use the GIF information about frame rate
+    public init(source: GIFSource, loop: Bool = true, placeholder: RawImage = RawImage(), errorImage: RawImage? = nil, frameRate: FrameRate = .dynamic) {
         self.source = source
         self.loop = loop
         self.placeholder = placeholder
         self.errorImage = errorImage
+        self.frameRate = frameRate
     }
     
     /// `GIFImage` is a `View` that loads a `Data` object from a source into `CoreImage.CGImageSource`, parse the image source
@@ -39,12 +42,13 @@ public struct GIFImage: View {
     ///   - loop: Flag to indicate if the GIF should be played only once or continue to loop
     ///   - placeholder: Image to be used before the source is loaded
     ///   - errorImage: If the stream fails, this image is used
-    public init?(url: String, loop: Bool = true, placeholder: RawImage = RawImage(), errorImage: RawImage? = nil) {
+    ///   - frameRate: Option to control the frame rate of the animation or to use the GIF information about frame rate
+    public init?(url: String, loop: Bool = true, placeholder: RawImage = RawImage(), errorImage: RawImage? = nil, frameRate: FrameRate = .dynamic) {
         guard let resolvedURL = URL(string: url) else {
             return nil
         }
         let source = GIFSource.remote(url: resolvedURL)
-        self.init(source: source, loop: loop, placeholder: placeholder, errorImage: errorImage)
+        self.init(source: source, loop: loop, placeholder: placeholder, errorImage: errorImage, frameRate: frameRate)
     }
     
     /// `GIFImage` is a `View` that loads a `Data` object from a source into `CoreImage.CGImageSource`, parse the image source
@@ -55,9 +59,10 @@ public struct GIFImage: View {
     ///   - loop: Flag to indicate if the GIF should be played only once or continue to loop
     ///   - placeholder: Image to be used before the source is loaded
     ///   - errorImage: If the stream fails, this image is used
-    public init(url: URL, loop: Bool = true, placeholder: RawImage = RawImage(), errorImage: RawImage? = nil) {
+    ///   - frameRate: Option to control the frame rate of the animation or to use the GIF information about frame rate
+    public init(url: URL, loop: Bool = true, placeholder: RawImage = RawImage(), errorImage: RawImage? = nil, frameRate: FrameRate = .dynamic) {
         let source = GIFSource.remote(url: url)
-        self.init(source: source, loop: loop, placeholder: placeholder, errorImage: errorImage)
+        self.init(source: source, loop: loop, placeholder: placeholder, errorImage: errorImage, frameRate: frameRate)
     }
     
     public var body: some View {
@@ -76,13 +81,24 @@ public struct GIFImage: View {
     
     func update(_ imageFrame: ImageFrame) async throws -> Void {
         frame = RawImage.create(with: imageFrame.image)
-        let interval = imageFrame.interval ?? kDefaultGIFFrameInterval
+        let interval: Double
+        switch(frameRate) {
+        case .static(let fps):
+            interval = (1.0 / Double(fps))
+        case .dynamic:
+            interval = imageFrame.interval ?? kDefaultGIFFrameInterval
+        }
         try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000.0))
     }
 }
 
 struct GIFImage_Previews: PreviewProvider {
+    static let gifURL = "https://64.media.tumblr.com/eb81c4d7288732e2b6a9e63c166c623a/tumblr_mi3vj5Api71ryhf5lo1_400.gif"
     static var previews: some View {
-        GIFImage(url: "https://64.media.tumblr.com/eb81c4d7288732e2b6a9e63c166c623a/tumblr_mi3vj5Api71ryhf5lo1_400.gif")
+        Group {
+            GIFImage(url: gifURL)
+            GIFImage(url: gifURL, frameRate: .static(fps: 24))
+            GIFImage(url: gifURL, frameRate: .static(fps: 120))
+        }
     }
 }

--- a/Sources/GIFImage.swift
+++ b/Sources/GIFImage.swift
@@ -81,10 +81,14 @@ public struct GIFImage: View {
     
     func update(_ imageFrame: ImageFrame) async throws -> Void {
         frame = RawImage.create(with: imageFrame.image)
+        let calculatedInterval = imageFrame.interval ?? kDefaultGIFFrameInterval
         let interval: Double
         switch(frameRate) {
         case .static(let fps):
             interval = (1.0 / Double(fps))
+        case .limited(let fps):
+            let intervalLimit = (1.0 / Double(fps))
+            interval = max(calculatedInterval, intervalLimit)
         case .dynamic:
             interval = imageFrame.interval ?? kDefaultGIFFrameInterval
         }
@@ -97,7 +101,7 @@ struct GIFImage_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             GIFImage(url: gifURL)
-            GIFImage(url: gifURL, frameRate: .static(fps: 24))
+            GIFImage(url: gifURL, frameRate: .limited(fps: 24))
             GIFImage(url: gifURL, frameRate: .static(fps: 120))
         }
     }

--- a/Sources/model/FrameRate.swift
+++ b/Sources/model/FrameRate.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  
+//
+//  Created by Igor Ferreira on 06/04/2022.
+//
+
+import Foundation
+
+public enum FrameRate {
+    case dynamic
+    case `static`(fps: Int)
+}

--- a/Sources/model/FrameRate.swift
+++ b/Sources/model/FrameRate.swift
@@ -9,5 +9,6 @@ import Foundation
 
 public enum FrameRate {
     case dynamic
+    case limited(fps: Int)
     case `static`(fps: Int)
 }


### PR DESCRIPTION
### Goal

Enable the user of the view to limit the FPS of each view

### Motivation

In many cases the user of the view may not want to rely on the GIF informed frame speed. For example, to cap high-speed GIF animations that may be over 120fps, given that iOS cannot deliver it.

### Implementation

1. Included a configuration enum to configured frame rate as dynamic, limited or fixed
2. Perform (in the View) necessary calculations to limit frame rate