### PR TITLE
Improve tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ playground.xcworkspace
 # .swiftpm
 
 .build/
+.tmp
 
 # CocoaPods
 #

--- a/Tests/ImageLoaderTests.swift
+++ b/Tests/ImageLoaderTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import GIFImage
 
 extension Double {
-    func equal(_ value: Double, precise: Int) -> Bool {
+    func equal(_ value: Double, precise: Int = 10) -> Bool {
         let denominator: Double = pow(10.0, Double(precise))
         let maxDiff: Double = 1 / denominator
         let realDiff: Double = self - value
@@ -69,7 +69,7 @@ class ImageLoaderTests: XCTestCase {
 
         let (frameCount, duration) = try await sequence.reduce((0, 0.0)) { partial, frame in (partial.0 + 1, partial.1 + (frame.interval ?? 0.0)) }
         XCTAssertEqual(frameCount, testGIFFrameCount)
-        XCTAssertTrue(duration.equal(testGIFDuration, precise: 2), "\(duration) is not equal to \(testGIFDuration)")
+        XCTAssertTrue(duration.equal(testGIFDuration), "\(duration) is not equal to \(testGIFDuration)")
     }
 
     func testFileSourceLoading() async throws {
@@ -81,7 +81,7 @@ class ImageLoaderTests: XCTestCase {
 
         let (frameCount, duration) = try await sequence.reduce((0, 0.0)) { partial, frame in (partial.0 + 1, partial.1 + (frame.interval ?? 0.0)) }
         XCTAssertEqual(frameCount, testGIFFrameCount)
-        XCTAssertTrue(duration.equal(testGIFDuration, precise: 2), "\(duration) is not equal to \(testGIFDuration)")
+        XCTAssertTrue(duration.equal(testGIFDuration), "\(duration) is not equal to \(testGIFDuration)")
     }
 
     func testRemoteSourceLoading() async throws {
@@ -94,7 +94,7 @@ class ImageLoaderTests: XCTestCase {
 
         let (frameCount, duration) = try await sequence.reduce((0, 0.0)) { partial, frame in (partial.0 + 1, partial.1 + (frame.interval ?? 0.0)) }
         XCTAssertEqual(frameCount, testGIFFrameCount)
-        XCTAssertTrue(duration.equal(testGIFDuration, precise: 2), "\(duration) is not equal to \(testGIFDuration)")
+        XCTAssertTrue(duration.equal(testGIFDuration), "\(duration) is not equal to \(testGIFDuration)")
     }
 
     func testSequenceLoadAndPresentationTime() async throws {

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -57,14 +57,16 @@ workflows:
             -scheme GIFImage \
             -sdk iphonesimulator \
             -destination 'platform=iOS Simulator,name=iPhone 8' \
-            build test
+            -parallel-testing-enabled \
+            build-for-testing test
 
             # Test tvOS layer
             xcodebuild -workspace .swiftpm/xcode/package.xcworkspace \
             -scheme GIFImage \
             -sdk appletvsimulator \
             -destination 'platform=tvOS Simulator,name=Apple TV' \
-            build test
+            -parallel-testing-enabled \
+            build-for-testing test
     - deploy-to-bitrise-io@2: {}
 meta:
   bitrise.io:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -47,26 +47,37 @@ workflows:
             # debug log
             set -x
 
+            # Prepare environment
             swift package reset
 
             # Test macOS layer
-            swift test
+            swift test --parallel --xunit-output "${BITRISE_DEPLOY_DIR}/swift_test.xml"
 
             # Test iOS layer
             xcodebuild -workspace .swiftpm/xcode/package.xcworkspace \
             -scheme GIFImage \
+            -derivedDataPath "${BITRISE_SOURCE_DIR}/.tmp" \
             -sdk iphonesimulator \
             -destination 'platform=iOS Simulator,name=iPhone 8' \
             -parallel-testing-enabled \
+            -enableCodeCoverage \
+            -quiet \
             build-for-testing test
 
             # Test tvOS layer
             xcodebuild -workspace .swiftpm/xcode/package.xcworkspace \
             -scheme GIFImage \
+            -derivedDataPath "${BITRISE_SOURCE_DIR}/.tmp" \
             -sdk appletvsimulator \
             -destination 'platform=tvOS Simulator,name=Apple TV' \
             -parallel-testing-enabled \
+            -enableCodeCoverage \
+            -quiet \
             build-for-testing test
+            
+            find "${BITRISE_SOURCE_DIR}/.tmp" -name "*.xcresult" -exec cp -r {} "${BITRISE_DEPLOY_DIR}" \;
+            
+            rm -rf "${BITRISE_SOURCE_DIR}/.tmp"
     - deploy-to-bitrise-io@2: {}
 meta:
   bitrise.io:


### PR DESCRIPTION
### Goal

Optimise test time

### Motivation

Given that all supported platforms are tested, we should aim to optimise the build/run time of those tests.

### Implementation

Replaces `build` with `build-for-testing` on xcodebuild commands and enables parallel testing. For the `swift test` command, the parallel is not enabled because the output of a ParallelTestRunner is not meaningful.