### PR TITLE
Include watchOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let packageName = "GIFImage"
 let package = Package(
     name: packageName,
     platforms: [
-        .macOS(.v12), .iOS(.v15), .tvOS(.v15)
+        .macOS(.v12), .iOS(.v15), .tvOS(.v15), .watchOS(.v8)
     ],
     products: [
         .library(name: packageName, targets: [packageName])

--- a/Sources/domain/CGImageSourceFrameSequence.swift
+++ b/Sources/domain/CGImageSourceFrameSequence.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CoreImage
+import ImageIO
 
 public struct CGImageSourceFrameSequence: AsyncSequence {
     public typealias Element = ImageFrame

--- a/Sources/domain/CGImageSourceIterator.swift
+++ b/Sources/domain/CGImageSourceIterator.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CoreImage
+import ImageIO
 
 public struct CGImageSourceIterator: AsyncIteratorProtocol {
 

--- a/Sources/extension/CFString+GIFImage.swift
+++ b/Sources/extension/CFString+GIFImage.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CoreImage
+import ImageIO
 
 extension CFString {
     var asKey: UnsafeMutableRawPointer {

--- a/Sources/extension/CGImageSource+GIFImage.swift
+++ b/Sources/extension/CGImageSource+GIFImage.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CoreImage
+import ImageIO
 
 extension CGImageSource {
     func intervalAtIndex(_ index: Int) -> TimeInterval? {

--- a/Sources/extension/Data+GIFImage.swift
+++ b/Sources/extension/Data+GIFImage.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import CoreImage
+import ImageIO
 
 extension Data {
     func imageAsyncSequence(loop: Bool) throws -> CGImageSourceFrameSequence {

--- a/Sources/model/ImageFrame.swift
+++ b/Sources/model/ImageFrame.swift
@@ -5,7 +5,8 @@
 //  Created by Igor Ferreira on 29/10/2020.
 //
 
-import CoreImage
+import ImageIO
+import Foundation
 
 public struct ImageFrame {
     public let image: CGImage

--- a/Sources/model/RawImage.swift
+++ b/Sources/model/RawImage.swift
@@ -5,7 +5,7 @@
 //  Created by Igor Ferreira on 05/04/2022.
 //
 
-import CoreImage
+import ImageIO
 import SwiftUI
 #if os(macOS)
 import AppKit

--- a/Tests/ImageLoaderTests.swift
+++ b/Tests/ImageLoaderTests.swift
@@ -56,7 +56,11 @@ class ImageLoaderTests: XCTestCase {
             _ = try await imageLoader.load(source: GIFSource.remote(url: url), loop: false)
             XCTFail("Sequence should throw error")
         } catch {
+            #if os(watchOS)
+            XCTAssertEqual((error as? URLError)?.code, URLError.Code.init(rawValue: -1001))
+            #else
             XCTAssertEqual((error as? URLError)?.code, URLError.Code.badURL)
+            #endif
         }
     }
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -67,6 +67,13 @@ workflows:
         - project_path: $WORKSPACE_PATH
         - xcodebuild_options: $BUILD_OPTIONS
         title: Xcode Test for tvOS
+    - xcode-test@4:
+        inputs:
+        - scheme: $BUILD_SCHEME
+        - destination: 'platform=watchOS Simulator,name=Apple Watch Series 7 - 41mm,OS=latest'
+        - project_path: $WORKSPACE_PATH
+        - xcodebuild_options: $BUILD_OPTIONS
+        title: Xcode Test for watchOS
     - deploy-to-bitrise-io@2: {}
 meta:
   bitrise.io:


### PR DESCRIPTION
### Goal

Add support to watchOS

### Motivation

There was no strong motivator to don't support watchOS. This PR should fix the shortcomes that prevents watchOS builds

### Implementation

- Replace CoreImage with ImageIO and handle the no-HTTP environment of watchOS on tests.