### PR TITLE
Make small improvements to swift lint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,10 @@
-line_length: 150
+disabled_rules:
+  - trailing_whitespace
+
+line_length:
+  warning: 150
+  ignores_comments: true
+
 excluded:
   - .build
   - .swiftpm


### PR DESCRIPTION
### Goal

Improve documentation syntax on code.

### Motivation

Because the line length also applied to comments, the documentation would need to have weird line breaks to respect it. This constrains the format of that tool

### Implementation

Correct configure SwiftLint