### PR TITLE
Include option to load from URLRequest

### DIFF
--- a/Sources/GIFImage+Init.swift
+++ b/Sources/GIFImage+Init.swift
@@ -64,7 +64,7 @@ public extension GIFImage {
             return nil
         }
         self.init(
-            source: GIFSource.remote(url: resolvedURL),
+            source: GIFSource.remoteURL(resolvedURL),
             animate: animate,
             loop: loop,
             placeholder: placeholder,
@@ -126,7 +126,38 @@ public extension GIFImage {
         loopAction: @Sendable @escaping (GIFSource) async throws -> Void = { _ in }
     ) {
         self.init(
-            source: GIFSource.remote(url: url),
+            source: GIFSource.remoteURL(url),
+            animate: animate,
+            loop: loop,
+            placeholder: placeholder,
+            errorImage: errorImage,
+            frameRate: frameRate,
+            loopAction: loopAction
+        )
+    }
+    
+    /// `GIFImage` is a `View` that loads a `Data` object from a source into `CoreImage.CGImageSource`, parse the image source
+    /// into frames and stream them based in the "Delay" key packaged on which frame item.
+    ///
+    /// - Parameters:
+    ///   - request: `URLRequest` of the image. The response is cached using `URLCache`
+    ///   - animate: A flag to indicate that GIF should animate or not. If non-animated, the first frame will be displayed
+    ///   - loop: Flag to indicate if the GIF should be played only once or continue to loop
+    ///   - placeholder: Image to be used before the source is loaded
+    ///   - errorImage: If the stream fails, this image is used
+    ///   - frameRate: Option to control the frame rate of the animation or to use the GIF information about frame rate
+    ///   - loopAction: Closure called whenever the GIF finishes rendering one cycle of the action
+    init(
+        request: URLRequest,
+        animate: Binding<Bool> = Binding.constant(true),
+        loop: Binding<Bool> = Binding.constant(true),
+        placeholder: RawImage = RawImage(),
+        errorImage: RawImage? = nil,
+        frameRate: FrameRate = .dynamic,
+        loopAction: @Sendable @escaping (GIFSource) async throws -> Void = { _ in }
+    ) {
+        self.init(
+            source: GIFSource.remoteRequest(request),
             animate: animate,
             loop: loop,
             placeholder: placeholder,

--- a/Sources/domain/CGImageSourceFrameSequence.swift
+++ b/Sources/domain/CGImageSourceFrameSequence.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ImageIO
 
-public struct CGImageSourceFrameSequence: AsyncSequence {
+public actor CGImageSourceFrameSequence: AsyncSequence {
     public typealias Element = ImageFrame
 
     public enum LoadError: Error {
@@ -40,7 +40,7 @@ public struct CGImageSourceFrameSequence: AsyncSequence {
         self.source = source
     }
 
-    public func makeAsyncIterator() -> CGImageSourceIterator {
+    nonisolated public func makeAsyncIterator() -> CGImageSourceIterator {
         CGImageSourceIterator(source: source)
     }
 }

--- a/Sources/domain/CGImageSourceIterator.swift
+++ b/Sources/domain/CGImageSourceIterator.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ImageIO
 
-public struct CGImageSourceIterator: AsyncIteratorProtocol {
+public actor CGImageSourceIterator: AsyncIteratorProtocol {
 
     public let frameCount: Int
     public let source: CGImageSource
@@ -20,16 +20,15 @@ public struct CGImageSourceIterator: AsyncIteratorProtocol {
         self.currentFrame = 0
     }
 
-    public mutating func next() async throws -> ImageFrame? {
+    public func next() async throws -> ImageFrame? {
         guard currentFrame < frameCount else {
             return nil
         }
 
-        let frame: ImageFrame?
-        if let image = CGImageSourceCreateImageAtIndex(source, currentFrame, nil) {
-            frame = ImageFrame(image: image, interval: source.intervalAtIndex(currentFrame))
+        let frame: ImageFrame? = if let image = CGImageSourceCreateImageAtIndex(source, currentFrame, nil) {
+            ImageFrame(image: image, interval: source.intervalAtIndex(currentFrame))
         } else {
-            frame = nil
+            nil
         }
         currentFrame += 1
         return frame

--- a/Sources/extension/Environment+GIFImage.swift
+++ b/Sources/extension/Environment+GIFImage.swift
@@ -19,3 +19,10 @@ extension EnvironmentValues {
         set { self[GIFImageEnvironment.self] = newValue }
     }
 }
+
+extension View {
+    @ViewBuilder
+    func with(imageLoader: ImageLoader) -> some View {
+        environment(\.imageLoader, imageLoader)
+    }
+}

--- a/Sources/model/GIFSource.swift
+++ b/Sources/model/GIFSource.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum GIFSource: Equatable {
+    @available(*, deprecated, renamed: "remoteURL(_:)")
     case remote(url: URL)
+    case remoteURL(_ url: URL)
+    case remoteRequest(_ request: URLRequest)
     case local(filePath: String)
     case `static`(data: Data)
 }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,7 +14,8 @@ app:
       is_expand: true
 meta:
   bitrise.io:
-    stack: osx-xcode-14.0.x
+    stack: osx-xcode-15.2.x
+    machine_type_id: g2-m1.4core
 trigger_map:
 - push_branch: main
   workflow: build


### PR DESCRIPTION
### Goal

Allow users to use URLRequest to configure the view

### Motivation

The environment in which the image is hosted may be more complex than a simple URL. For example, use Authorization header in the request.

### Implementation

Includes the new source enum and implement method on URLRequest to get Data. Also, provides an init for the View that receives an URLRequest as source.