### PR TITLE
Create Github test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Link SwiftLint or install it
+        run: brew link --overwrite swiftlint || brew install swiftlint
+      - name: Run swiftlint
+        run: swiftlint
+      - name: Run test
+        run: swift test


### PR DESCRIPTION
### Goal

Move CI tests into Github

### Motivation

To create a single development asset, remove Bitrise

### Implementation

Create a Github actions which runs Swift Lint and Package test